### PR TITLE
Fix minor typo in purchase template

### DIFF
--- a/actdocs/templates/user/purchase
+++ b/actdocs/templates/user/purchase
@@ -116,7 +116,7 @@ if (window.act) {
 <p>
 <t><de>Nach Abschluss Ihrer Bestellung erhalten Sie eine Rechnung.
 Bitte &uuml;berweisen Sie den Rechnungsbetrag auf das genannte Konto. </de>
-<en>We will email you a invoice payable by bank transfer after completing your order.
+<en>We will email you an invoice payable by bank transfer after completing your order.
 International visitors please contact us for cash payment on the conference day.</en></t>
 </p>
 


### PR DESCRIPTION
While submitting the payment form, I happened to noticed that an 'n' was missing from "an invoice".  This change fixes the issue.

Hope this helps!